### PR TITLE
Remaining Permission Cleanup

### DIFF
--- a/src/main/java/com/checkinn/checkinn/CheckInnApplication.java
+++ b/src/main/java/com/checkinn/checkinn/CheckInnApplication.java
@@ -7,10 +7,10 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class CheckInnApplication {
 	public static void main(String[] args) {
-//		Dotenv dotenv = Dotenv.load();
-//
-//		dotenv.entries().forEach(entry -> System.setProperty(entry.getKey(),
-//				entry.getValue()));
+		Dotenv dotenv = Dotenv.load();
+
+		dotenv.entries().forEach(entry -> System.setProperty(entry.getKey(),
+				entry.getValue()));
 
 		SpringApplication.run(CheckInnApplication.class, args);
 	}

--- a/src/main/java/com/checkinn/checkinn/CheckInnApplication.java
+++ b/src/main/java/com/checkinn/checkinn/CheckInnApplication.java
@@ -7,10 +7,10 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class CheckInnApplication {
 	public static void main(String[] args) {
-		Dotenv dotenv = Dotenv.load();
-
-		dotenv.entries().forEach(entry -> System.setProperty(entry.getKey(),
-				entry.getValue()));
+//		Dotenv dotenv = Dotenv.load();
+//
+//		dotenv.entries().forEach(entry -> System.setProperty(entry.getKey(),
+//				entry.getValue()));
 
 		SpringApplication.run(CheckInnApplication.class, args);
 	}

--- a/src/main/java/com/checkinn/checkinn/Controllers/ReservationController.java
+++ b/src/main/java/com/checkinn/checkinn/Controllers/ReservationController.java
@@ -63,8 +63,8 @@ public class ReservationController {
 
     @PatchMapping("/edit/{reservationId}")
     public ResponseEntity<String> editReservation(@RequestHeader (GeneralConstants.AUTH_HEADER_NAME) String token, @PathVariable int reservationId, @RequestBody Reservation reservation) {
-        int userId = this.authService.decodeToken(token);
-        return ResponseEntity.ok().body(reservationService.editReservation(userId, reservationId, reservation));
+        authService.tokenMatchesUserThrowOtherwise(token, reservationService.getUserByReservationId(reservationId).getUserId());
+        return ResponseEntity.ok().body(reservationService.editReservation(reservationId, reservation));
     }
 
     @PostMapping("/create/{hotelId}")

--- a/src/main/java/com/checkinn/checkinn/Controllers/ReviewController.java
+++ b/src/main/java/com/checkinn/checkinn/Controllers/ReviewController.java
@@ -59,8 +59,9 @@ public class ReviewController {
 
     @PatchMapping("/edit/{reviewId}")
     public ResponseEntity<String> editReview(@RequestHeader (GeneralConstants.AUTH_HEADER_NAME) String token, @PathVariable int reviewId, @RequestBody Review review) {
+        authService.tokenMatchesUserThrowOtherwise(token, reviewService.getUserByReviewId(reviewId).getUserId());
         int userId = this.authService.decodeToken(token);
-        return ResponseEntity.ok().body(reviewService.editReview(userId, reviewId, review));
+        return ResponseEntity.ok().body(reviewService.editReview(userId, review));
     }
 
     @PostMapping("/create")

--- a/src/main/java/com/checkinn/checkinn/Services/ReservationService.java
+++ b/src/main/java/com/checkinn/checkinn/Services/ReservationService.java
@@ -57,10 +57,9 @@ public class ReservationService {
     /*
      *  better date validation to be added later
      */
-    public String editReservation(int userId, int reservationId, Reservation newReservation) {
+    public String editReservation(int reservationId, Reservation newReservation) {
         Reservation r = reservationRepository.findById(reservationId).orElseThrow(
                 () -> new ResponseStatusException(HttpStatus.NOT_FOUND, "RESERVATION NOT FOUND"));
-        if (r.getUser().getUserId() != userId) throw new ResponseStatusException(HttpStatus.FORBIDDEN, "UNAUTHORIZED");
         if (!dateValidation(newReservation.getCheckInTime(), newReservation.getCheckOutTime())) throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "INVALID DATES");
 
         r.setCheckInTime(newReservation.getCheckInTime());

--- a/src/main/java/com/checkinn/checkinn/Services/ReviewService.java
+++ b/src/main/java/com/checkinn/checkinn/Services/ReviewService.java
@@ -70,13 +70,10 @@ public class ReviewService {
         return "REVIEW DELETED";
     }
 
-    public String editReview(int userId, int reviewId, Review review) {
+    public String editReview(int reviewId, Review review) {
         Optional<Review> resp = reviewRepository.findById(reviewId);
         if (resp.isPresent()){
             Review r = resp.get();
-            if (r.getUser().getUserId() != userId) {
-                throw new ResponseStatusException(HttpStatus.FORBIDDEN, "UNAUTHORIZED");
-            }
             if (review.getDescription().isBlank()) throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "INVALID REVIEW INFORMATION");
             if (review.getRating()<1 || review.getRating()>5) throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "INVALID REVIEW INFORMATION");
             if (review.getTitle().isBlank()) throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "INVALID REVIEW INFORMATION");

--- a/src/test/java/com/checkinn/checkinn/Services/ReservationServiceTests.java
+++ b/src/test/java/com/checkinn/checkinn/Services/ReservationServiceTests.java
@@ -133,7 +133,7 @@ class ReservationServiceTests {
 
         // CUT and Assert
         assertDoesNotThrow(() -> {
-            reservationService.editReservation(TEST_USER.getUserId(),oldReservation.getReservationId(), newReservation);
+            reservationService.editReservation(oldReservation.getReservationId(), newReservation);
         });
     }
 
@@ -156,43 +156,12 @@ class ReservationServiceTests {
 
         try {
         // CUT
-            reservationService.editReservation(TEST_USER.getUserId(), oldReservation.getReservationId(), newReservation);
+            reservationService.editReservation(oldReservation.getReservationId(), newReservation);
             fail("Time validation failed");
         }
         catch (ResponseStatusException e) {
         // Assert
             assertEquals(HttpStatus.BAD_REQUEST, e.getStatusCode());
-        }
-        catch (Exception f) {
-            fail("Something else went wrong: " + f.getMessage());
-        }
-    }
-
-    @Test
-    void edit_reservation_incorrect_user() {
-        // Setup
-        Reservation oldReservation = new Reservation();
-        oldReservation.setReservationId(2);
-        oldReservation.setHotel(TEST_HOTEL);
-        oldReservation.setUser(TEST_USER);
-        oldReservation.setCheckInTime(new Date(System.currentTimeMillis() + 1000 * 60 * 60 * 24)); // 24 hours from now
-        oldReservation.setCheckOutTime(new Date(System.currentTimeMillis() + 1000 * 60 * 60 * 72)); // 72 hours from now
-
-        Reservation newReservation = new Reservation();
-        newReservation.setCheckInTime(new Date(System.currentTimeMillis() + 1000 * 60 * 60 * 48)); // 48 hours from now
-        newReservation.setCheckOutTime(new Date(System.currentTimeMillis() + 1000 * 60 * 60 * 96)); // 96 hours from now
-
-        // Mock
-        when(reservationRepository.findById(oldReservation.getReservationId())).thenReturn(Optional.of(oldReservation));
-
-        try {
-            // CUT
-            reservationService.editReservation(TEST_USER.getUserId() + 404, oldReservation.getReservationId(), newReservation);
-            fail("User validation failed");
-        }
-        catch (ResponseStatusException e) {
-            // Assert
-            assertEquals(HttpStatus.FORBIDDEN, e.getStatusCode());
         }
         catch (Exception f) {
             fail("Something else went wrong: " + f.getMessage());

--- a/src/test/java/com/checkinn/checkinn/Services/ReviewServiceTests.java
+++ b/src/test/java/com/checkinn/checkinn/Services/ReviewServiceTests.java
@@ -98,44 +98,7 @@ class ReviewServiceTests {
         when(reviewRepository.findById(review.getReviewId())).thenReturn(Optional.of(review));
 
         // CUT
-        reviewService.editReview(TEST_USER.getUserId(), review.getReviewId(), newReview);
-    }
-
-    @Test
-    void edit_review_incorrect_user() {
-
-        // Setup
-        Review review = new Review();
-        review.setReviewId(2);
-        review.setUser(TEST_USER);
-        review.setHotel(TEST_HOTEL);
-        review.setTitle("Old Title");
-        review.setRating(5);
-        review.setDescription("Old Description");
-
-        Review newReview = new Review();
-        newReview.setReviewId(2);
-        newReview.setUser(TEST_USER);
-        newReview.setHotel(TEST_HOTEL);
-        newReview.setTitle("New Title");
-        newReview.setRating(4);
-        newReview.setDescription("New Description");
-
-        // Mock
-        when(reviewRepository.findById(review.getReviewId())).thenReturn(Optional.of(review));
-
-        try {
-        // CUT
-            reviewService.editReview(TEST_USER.getUserId() + 404, review.getReviewId(), newReview);
-            fail("How did this succeed");
-        }
-        catch (ResponseStatusException e) {
-        // Assert
-            assertEquals(HttpStatus.FORBIDDEN, e.getStatusCode());
-        }
-        catch (Exception f) {
-            fail("Something else went wrong: " + f.getMessage());
-        }
+        reviewService.editReview(review.getReviewId(), newReview);
     }
 
     @Test
@@ -147,7 +110,7 @@ class ReviewServiceTests {
 
         try {
             // CUT
-            reviewService.editReview(TEST_USER.getUserId(), reviewId, new Review());
+            reviewService.editReview(reviewId, new Review());
             fail("How did this succeed");
         }
         catch (ResponseStatusException e) {
@@ -185,7 +148,7 @@ class ReviewServiceTests {
 
         try {
             // CUT
-            reviewService.editReview(TEST_USER.getUserId(), review.getReviewId(), newReview);
+            reviewService.editReview(review.getReviewId(), newReview);
             fail("How did this succeed");
         }
         catch (ResponseStatusException e) {
@@ -222,7 +185,7 @@ class ReviewServiceTests {
 
         try {
             // CUT
-            reviewService.editReview(TEST_USER.getUserId(), review.getReviewId(), newReview);
+            reviewService.editReview(review.getReviewId(), newReview);
             fail("How did this succeed");
         }
         catch (ResponseStatusException e) {
@@ -260,7 +223,7 @@ class ReviewServiceTests {
 
         try {
             // CUT
-            reviewService.editReview(TEST_USER.getUserId(), review.getReviewId(), newReview);
+            reviewService.editReview(review.getReviewId(), newReview);
             fail("How did this succeed");
         }
         catch (ResponseStatusException e) {


### PR DESCRIPTION
Doubled back and moved remaining permission check logic out of the service layer and into the controller layer
Removed any service layer tests that checked for matching users as a result
Remaining HttpStatus.FORBIDDEN errors are now only thrown by AuthService for permission checks